### PR TITLE
make buildsystem yocto friendly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,8 @@
 export CC=/usr/bin/clang
 export CXX=/usr/bin/clang++
 
+TOPDIR=$(pwd)
+
 cd 3rdparty
 if [ ! -d ravenna-alsa-lkm.git ]; then
   git clone https://bitbucket.org/MergingTechnologies/ravenna-alsa-lkm.git
@@ -44,7 +46,7 @@ cd ..
 
 cd daemon
 echo "Building aes67-daemon ..."
-cmake -DWITH_AVAHI=ON .
+cmake -DCPP_HTTPLIB_DIR="$TOPDIR"/3rdparty/cpp-httplib -DRAVENNA_ALSA_LKM_DIR="$TOPDIR"/3rdparty/ravenna-alsa-lkm -DENABLE_TESTS=ON -DWITH_AVAHI=ON .
 make
 cd ..
 

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -1,20 +1,43 @@
 cmake_minimum_required(VERSION 3.7.0)
+
 project(aes67-daemon CXX)
-enable_testing()
+
+option(ENABLE_TESTS "Enable tests. Not recommended when cross-compiling." OFF)
+if( ENABLE_TESTS )
+    enable_testing()
+endif()
+
 option(WITH_AVAHI "Include mDNS support via Avahi" OFF)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-g -DBOOST_LOG_DYN_LINK -DBOOST_LOG_USE_NATIVE_SYSLOG -Wall")
-set(RAVENNA_ALSA_LKM "../3rdparty/ravenna-alsa-lkm/")
-set(CPP_HTTPLIB " ../3rdparty/cpp-httplib/")
+
+# ravena lkm _should_ be provided by the CLI. Nonetheless, we should be able
+# to find it in system dirs too...
+if ( NOT RAVENNNA_ALSA_LKM_DIR )
+    find_path(RAVENNA_ALSA_LKM_DIR "common/MergingRAVENNACommon.h" REQUIRED)
+endif()
+
+# use sysroot cpp-http lib unless one was explicitly provided  in cmdline
+if ( NOT CPP_HTTPLIB_DIR )
+    find_path( CPP_HTTPLIB_DIR "httplib.h" REQUIRED)
+endif()
+
 find_library(AVAHI_LIBRARY-COMMON NAMES avahi-common)
 find_library(AVAHI_LIBRARY-CLIENT NAMES avahi-client)
 find_path(AVAHI_INCLUDE_DIR avahi-client/publish.h)
 set(AVAHI_LIBRARIES ${AVAHI_LIBRARY-COMMON} ${AVAHI_LIBRARY-CLIENT})
 set(AVAHI_INCLUDE_DIRS ${AVAHI_INCLUDE_DIR})
+
 find_package(Boost COMPONENTS system thread log program_options REQUIRED)
-include_directories(aes67-daemon ${RAVENNA_ALSA_LKM}/common ${RAVENNA_ALSA_LKM}/driver ${CPP_HTTPLIB} ${Boost_INCLUDE_DIR})
+include_directories(aes67-daemon ${RAVENNA_ALSA_LKM_DIR}/common ${RAVENNA_ALSA_LKM_DIR}/driver ${CPP_HTTPLIB_DIR} ${Boost_INCLUDE_DIR})
+add_compile_definitions( BOOST_LOG_DYN_LINK BOOST_LOG_USE_NATIVE_SYSLOG )
+add_compile_options( -Wall )
 add_executable(aes67-daemon error_code.cpp json.cpp main.cpp driver_handler.cpp driver_manager.cpp session_manager.cpp http_server.cpp config.cpp interface.cpp log.cpp sap.cpp browser.cpp rtsp_client.cpp mdns_client.cpp mdns_server.cpp rtsp_server.cpp utils.cpp)
-add_subdirectory(tests)
+
+if( ENABLE_TESTS )
+    add_subdirectory(tests)
+endif()
+
+
 target_link_libraries(aes67-daemon ${Boost_LIBRARIES})
 if(WITH_AVAHI)
   MESSAGE(STATUS "WITH_AVAHI")

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -29,7 +29,7 @@ set(AVAHI_INCLUDE_DIRS ${AVAHI_INCLUDE_DIR})
 
 find_package(Boost COMPONENTS system thread log program_options REQUIRED)
 include_directories(aes67-daemon ${RAVENNA_ALSA_LKM_DIR}/common ${RAVENNA_ALSA_LKM_DIR}/driver ${CPP_HTTPLIB_DIR} ${Boost_INCLUDE_DIR})
-add_compile_definitions( BOOST_LOG_DYN_LINK BOOST_LOG_USE_NATIVE_SYSLOG )
+add_definitions( -DBOOST_LOG_DYN_LINK -DBOOST_LOG_USE_NATIVE_SYSLOG )
 add_compile_options( -Wall )
 add_executable(aes67-daemon error_code.cpp json.cpp main.cpp driver_handler.cpp driver_manager.cpp session_manager.cpp http_server.cpp config.cpp interface.cpp log.cpp sap.cpp browser.cpp rtsp_client.cpp mdns_client.cpp mdns_server.cpp rtsp_server.cpp utils.cpp)
 

--- a/daemon/tests/CMakeLists.txt
+++ b/daemon/tests/CMakeLists.txt
@@ -1,10 +1,23 @@
 cmake_minimum_required(VERSION 3.7.0)
 project(daemon-test CXX)
 set(CMAKE_CXX_STANDARD 17)
-set(CPP_HTTPLIB " ../3rdparty/cpp-httplib/")
-set(CMAKE_CXX_FLAGS "-g -O3 -DBOOST_LOG_DYN_LINK -DBOOST_LOG_USE_NATIVE_SYSLOG -Wall")
+
+# use sysroot cpp-http lib unless one was explicitly provided  in cmdline
+if ( NOT CPP_HTTPLIB_DIR )
+    find_path( CPP_HTTPLIB_DIR "httplib.h" REQUIRED)
+endif()
+
+# ravena lkm _should_ be provided by the CLI. Nonetheless, we should be able
+# to find it in system dirs too...
+if ( NOT RAVENNNA_ALSA_LKM_DIR )
+    find_path(RAVENNA_ALSA_LKM_DIR "common/MergingRAVENNACommon.h" REQUIRED)
+endif()
+
+add_definitions( -DBOOST_LOG_DYN_LINK -DBOOST_LOG_USE_NATIVE_SYSLOG )
+add_compile_options( -Wall )
+
 find_package(Boost COMPONENTS unit_test_framework filesystem system thread REQUIRED)
-include_directories(aes67-daemon ${CPP_HTTPLIB} ${Boost_INCLUDE_DIR})
+include_directories(aes67-daemon ${CPP_HTTPLIB_DIR} ${RAVENNA_ALSA_LKM_DIR}/common ${RAVENNA_ALSA_LKM_DIR}/driver ${Boost_INCLUDE_DIR})
 add_executable(daemon-test daemon_test.cpp)
 target_link_libraries(daemon-test ${Boost_LIBRARIES})
 add_test(daemon-test daemon-test)


### PR DESCRIPTION
I made some changes to the CMakeLists.txt of the daemon so that it is easier to build it within yocto.
The most significant change was to remove the direct assignment to CMAKE_CXX_FLAGS, as this breaks havoc with the yocto build system. It was not the recommended practice with cmake anyway, so I moved those compilation flags into appropriate locations (definitions, options, etc...).
The rest was mostly related to tidiness.
* daemon:
    - do not assume filesystem hierarchy in CMakeLists.txt
    - do not replace default CXX compilation flags to avoid breaking builds with external toolchain (e.g. yocto)
    - allow for tests to be enabled/disabled
    - allow for cpp-httplib dir to be provided by hand; otherwise search for it in system locations
    - allow for the location of the ravenna alsa lkm to be provided by hand, otherwise look for it in system locations