### PR TITLE
Fix 3rd party directory checks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,14 +10,14 @@ export CXX=/usr/bin/clang++
 TOPDIR=$(pwd)
 
 cd 3rdparty
-if [ ! -d ravenna-alsa-lkm.git ]; then
+if [ ! -d ravenna-alsa-lkm ]; then
   git clone --single-branch --branch aes67-daemon https://github.com/bondagit/ravenna-alsa-lkm.git
   cd ravenna-alsa-lkm/driver
   make
   cd ../..
 fi
 
-if [ ! -d cpp-httplib.git ]; then
+if [ ! -d cpp-httplib ]; then
   git clone https://github.com/yhirose/cpp-httplib.git
   cd cpp-httplib
   git checkout 42f9f9107f87ad2ee04be117dbbadd621c449552


### PR DESCRIPTION
I might have misunderstood the intended purpose of the directory checks in the build script.
My edit checks for the actual directories created by checking out the `ravenna-alsa-lkm` and `cpp-httplib` repositories.