### PR TITLE
Separate out Ubuntu installation packages

### DIFF
--- a/ubuntu-packages.sh
+++ b/ubuntu-packages.sh
@@ -12,7 +12,10 @@ sudo apt-get install -y cmake
 # sudo apt-get install -y npm
 sudo apt-get install -y libboost-all-dev
 sudo apt-get install -y valgrind
-sudo apt-get install -y linux-sound-base alsa-base alsa-utils libasound2-dev
+sudo apt-get install -y linux-sound-base
+sudo apt-get install -y alsa-base
+sudo apt-get install -y alsa-utils
+sudo apt-get install -y libasound2-dev
 sudo apt-get install -y linuxptp
 sudo apt-get install -y libavahi-client-dev
 sudo apt install -y linux-headers-$(uname -r)


### PR DESCRIPTION
This seems to work better on Ubuntu Studio 21.10 - 5.13.0-39-lowlatency. The script as it was, for whatever reason, wouldn't download and install libasound2-dev but separating it out solved this issue.