### PR TITLE
Correct case for kHz (kilohertz)

### DIFF
--- a/DEVICES.md
+++ b/DEVICES.md
@@ -17,7 +17,7 @@ Before running any interoperability test configure the AES67 daemon with the fol
 
 * open the daemon configuration file *daemon.conf* and change the following parameters:
   * set network interface name to your Ethernet card: *"interface\_name": "eth0"*
-  * set default sample rate to 48Khz: *"sample\_rate": 48000*
+  * set default sample rate to 48kHz: *"sample\_rate": 48000*
   * set TIC frame size @1FS (samples) to 48 samples: *"tic\_frame\_size\_at\_1fs": 48*
 * verify that PulseAdio is not running. See [PulseAudio](README.md#notes).
 * install the ALSA RAVENNA/AES67 module with:     
@@ -29,7 +29,7 @@ Before running any interoperability test configure the AES67 daemon with the fol
       aes67-daemon -c daemon.conf
 
 * open the Daemon WebUI *http://[address:8080]* and do the following:
-  * go to Config tab and verify that the sample rate is set to 48KHz and the TIC frame size @1FS is set to 48 samples
+  * go to Config tab and verify that the sample rate is set to 48kHz and the TIC frame size @1FS is set to 48 samples
   * go to Sources tab and add a new Source using the plus button
     * set Codec to L24 
     * set Max samples per packet to 48 samples

--- a/USB_GADGET.md
+++ b/USB_GADGET.md
@@ -38,7 +38,7 @@ The expected output is:
 
        0 [UAC1Gadget     ]: UAC1_Gadget - UAC1_Gadget
                             UAC1_Gadget 0
-By default this new audio codec works with a sample rate of 48Khz, 2 channels and sample format *S16_LE*.
+By default this new audio codec works with a sample rate of 48kHz, 2 channels and sample format *S16_LE*.
 
 On the PC new audio input and output devices show up. 
 The name assigned to these depend on the OS.

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -359,7 +359,7 @@ where:
 > JSON number specifying the max number of samples contained in one RTP packet.    
 > Valid values are 12, 16, 48, 96, 192.        
 > See the table below for correspondent max RTP packet duration: 
-> |     | 44.1Khz  | 48Khz   | 96Khz   |
+> |     | 44.1kHz  | 48kHz   | 96kHz   |
 > |-----|----------|---------|---------|
 > | 12  | 272µs    | 250µs   | 125µs   |
 > | 16  | 363µs    | 333µs   | 166µs   |

--- a/webui/src/SinkEdit.jsx
+++ b/webui/src/SinkEdit.jsx
@@ -197,11 +197,11 @@ class SinkEdit extends Component {
               <th align="left"> <label>Delay (samples) </label> </th>
               <th align="left">
 	        <select value={this.state.delay} onChange={e => this.setState({delay: e.target.value})}>
-                  <option value="192">192 - 4ms@48KHz</option>
-                  <option value="384">384 - 8ms@48KHz</option>
-                  <option value="576">576 - 12ms@48KHz</option>
-                  <option value="768">768 - 16ms@48KHz</option>
-                  <option value="960">960 - 20ms@48KHz</option>
+                  <option value="192">192 - 4ms@48kHz</option>
+                  <option value="384">384 - 8ms@48kHz</option>
+                  <option value="576">576 - 12ms@48kHz</option>
+                  <option value="768">768 - 16ms@48kHz</option>
+                  <option value="960">960 - 20ms@48kHz</option>
                 </select>
               </th>
             </tr>


### PR DESCRIPTION
It's a minor issue, I think that it looks better with correct casing, kilohertz is kHz when following the SI system.