### PR TITLE
Update SDP on session version changes

### DIFF
--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -173,6 +173,11 @@ int main(int argc, char* argv[]) {
           break;
         }
 
+        /* Use a newer version of source if the current version isn't available anymore.
+         * This typically happens when equipment is restarted. */
+        std::list<RemoteSource> sources = browser->get_remote_sources();
+        session_manager->update_sources(sources);
+
         std::this_thread::sleep_for(std::chrono::seconds(1));
       }
 


### PR DESCRIPTION
Change to a new session version when the version specified in the SDP isn't available anymore. The typical scenario when this is needed is equipment restart.
This solution is based on comparing the globally unique identifier for a session as specified in RFC4566 - SDP: Session Description Protocol.

This should be the least intrusive solution to the problem with loosing connection with equipment that is re-started or re-configured. A more intrusive and probably better solution is to always use the latest announced version of a session.

From RFC4566:
[5.2](https://datatracker.ietf.org/doc/html/rfc4566#section-5.2).  Origin ("o=")

      o=<username> <sess-id> <sess-version> <nettype> <addrtype>
        <unicast-address>

   The "o=" field gives the originator of the session (her username and
   the address of the user's host) plus a session identifier and version
   number:

   \<username\> is the user's login on the originating host, or it is "-"
      if the originating host does not support the concept of user IDs.
      The \<username\> MUST NOT contain spaces.

   \<sess-id\> is a numeric string such that the tuple of \<username\>,
      \<sess-id\>, \<nettype\>, \<addrtype\>, and \<unicast-address\> forms a
      globally unique identifier for the session.  The method of
      \<sess-id\> allocation is up to the creating tool, but it has been
      suggested that a Network Time Protocol (NTP) format timestamp be
      used to ensure uniqueness [[13](https://datatracker.ietf.org/doc/html/rfc4566#ref-13)].