### PR TITLE
Fix HttpServer::init() erroneous return value

### DIFF
--- a/daemon/http_server.cpp
+++ b/daemon/http_server.cpp
@@ -352,11 +352,12 @@ bool HttpServer::init() {
   httplib::Client cli(config_->get_ip_addr_str().c_str(),
                       config_->get_http_port());
   int retry = 3;
-  while (retry--) {
+  while (retry) {
     auto res = cli.Get("/api/config");
     if (res && res->status == 200) {
       break;
     }
+    --retry;
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
   return retry;


### PR DESCRIPTION
Fix bug HttpServer::init() would incorrectly return true when the server is not responding, and sometimes would incorrectly return false when the server is responding.

Using postfix decrement in the while condition caused the returned value to be one less than intended, making an intended 0 value actually -1 which was cast to true, and an intended 1 value actually 0 and returned as false.