### PR TITLE
Change last seen to seconds since last announcement

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -651,7 +651,7 @@ where:
 
 > **last\_seen**
 > JSON number specifying the last time the source was announced.
-> This time is expressed in seconds since the daemon startup.
+> This time is expressed in seconds since the source was announced.
 
 > **announce_period**
 > JSON number specifying the meausured period in seconds between the last source announcements.

--- a/daemon/browser.cpp
+++ b/daemon/browser.cpp
@@ -102,6 +102,7 @@ bool Browser::worker() {
           if ((last_update_ - upd_source.last_seen) != 0) {
             upd_source.announce_period = last_update_ - upd_source.last_seen;
             upd_source.last_seen = last_update_;
+            upd_source.last_seen_timepoint = steady_clock::now();
             sources_.replace(it, upd_source);
           }
         } else {
@@ -168,6 +169,7 @@ void Browser::on_change_rtsp_source(const std::string& name,
       upd_source.origin = sdp_get_origin(s.sdp);
       upd_source.sdp = s.sdp;
       upd_source.last_seen = last_update_;
+      upd_source.last_seen_timepoint = steady_clock::now();
       sources_.get<name_tag>().replace(it, upd_source);
       return;
     }

--- a/daemon/browser.hpp
+++ b/daemon/browser.hpp
@@ -38,6 +38,7 @@
 #include "utils.hpp"
 
 using namespace boost::multi_index;
+using namespace std::chrono;
 
 struct RemoteSource {
   std::string id;
@@ -49,6 +50,7 @@ struct RemoteSource {
   std::string sdp;
   uint32_t last_seen{0};       /* seconds from daemon startup */
   uint32_t announce_period{0}; /* period between annoucements */
+  time_point<steady_clock> last_seen_timepoint{steady_clock::now()};
 };
 
 class Browser : public MDNSClient {

--- a/daemon/json.cpp
+++ b/daemon/json.cpp
@@ -23,10 +23,14 @@
 #include <iostream>
 #include <regex>
 #include <string>
+#include <chrono>
 
 #include "log.hpp"
 #include "utils.hpp"
 #include "json.hpp"
+
+using namespace std::chrono;
+using second_t = duration<double, std::ratio<1> >;
 
 static inline std::string remove_undesired_chars(const std::string& s) {
   std::regex html_regex("[^ A-Za-z0-9:~.,_/=%()\\r\\n\\t\?#-]?");
@@ -253,7 +257,7 @@ std::string remote_source_to_json(const RemoteSource& source) {
      << ",\n    \"domain\": \"" << escape_json(source.domain) << "\""
      << ",\n    \"address\": \"" << escape_json(source.address) << "\""
      << ",\n    \"sdp\": \"" << escape_json(source.sdp) << "\""
-     << ",\n    \"last_seen\": " << unsigned(source.last_seen)
+     << ",\n    \"last_seen\": " << unsigned(duration_cast<second_t>(steady_clock::now() - source.last_seen_timepoint).count())
      << ",\n    \"announce_period\": " << unsigned(source.announce_period)
      << " \n  }";
   return ss.str();


### PR DESCRIPTION
Change last seen from seconds since startup to seconds since the source was announced.

It can be hard to see if the source is lost based on the last_seen value. It's probably easy to make the code better and without adding the extra variable last_seen_timestamp.