### PR TITLE
Fix GCC 12.3.0 compilation issue

### DIFF
--- a/daemon/log.cpp
+++ b/daemon/log.cpp
@@ -23,10 +23,13 @@
 #include <boost/log/sources/severity_logger.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/console.hpp>
+#include <boost/lexical_cast.hpp>
+
 #include <vector>
 
 #include "config.hpp"
 #include "log.hpp"
+
 
 namespace logging = boost::log;
 namespace src = boost::log::sources;


### PR DESCRIPTION
On CRUX 3.7, GCC 12.3.0, this  fixes the compilation issue