### PR TITLE
WebUI listening addr can be configured separately from AES67 interface

### DIFF
--- a/daemon/config.hpp
+++ b/daemon/config.hpp
@@ -33,6 +33,7 @@ class Config {
                                        bool driver_restart);
 
   /* attributes retrieved from config json */
+  const std::string& get_http_addr_str() const { return http_addr_str_; };
   uint16_t get_http_port() const { return http_port_; };
   uint16_t get_rtsp_port() const { return rtsp_port_; };
   const std::string& get_http_base_dir() const { return http_base_dir_; };
@@ -69,6 +70,9 @@ class Config {
     return ptp_status_script_;
   }
 
+  void set_http_addr_str(std::string_view http_addr_str) {
+      http_addr_str_ = http_addr_str;
+  };
   void set_http_port(uint16_t http_port) { http_port_ = http_port; };
   void set_rtsp_port(uint16_t rtsp_port) { rtsp_port_ = rtsp_port; };
   void set_http_base_dir(std::string_view http_base_dir) {
@@ -129,7 +133,8 @@ class Config {
   void set_driver_restart(bool restart) { driver_restart_ = restart; }
 
   friend bool operator!=(const Config& lhs, const Config& rhs) {
-    return lhs.get_http_port() != rhs.get_http_port() ||
+    return lhs.get_http_addr_str() != rhs.get_http_addr_str() ||
+           lhs.get_http_port() != rhs.get_http_port() ||
            lhs.get_rtsp_port() != rhs.get_rtsp_port() ||
            lhs.get_http_base_dir() != rhs.get_http_base_dir() ||
            lhs.get_log_severity() != rhs.get_log_severity() ||
@@ -157,6 +162,7 @@ class Config {
 
  private:
   /* from json */
+  std::string http_addr_str_{""};
   uint16_t http_port_{8080};
   uint16_t rtsp_port_{8854};
   std::string http_base_dir_{"../webui/dist"};

--- a/daemon/http_server.cpp
+++ b/daemon/http_server.cpp
@@ -334,13 +334,17 @@ bool HttpServer::init() {
   });
 
   /* start http server on a separate thread */
+  auto http_addr=config_->get_http_addr_str();
+  if(http_addr.empty())
+      http_addr=config_->get_ip_addr_str();
+  
   res_ = std::async(std::launch::async, [&]() {
     try {
-      svr_.listen(config_->get_ip_addr_str().c_str(), config_->get_http_port());
+        svr_.listen(http_addr.c_str(), config_->get_http_port());
     } catch (...) {
       BOOST_LOG_TRIVIAL(fatal)
           << "http_server:: "
-          << "failed to listen to " << config_->get_ip_addr_str() << ":"
+          << "failed to listen to " << http_addr << ":"
           << config_->get_http_port();
       return false;
     }

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -61,10 +61,12 @@ int main(int argc, char* argv[]) {
   po::options_description desc("Options");
   desc.add_options()("version,v", "Print daemon version and exit")(
       "config,c", po::value<std::string>()->default_value("/etc/daemon.conf"),
-      "daemon configuration file")("http_port,p", po::value<int>(),
-                                   "HTTP server port")("help,h",
-                                                       "Print this help "
-                                                       "message");
+      "daemon configuration file")(
+          "http_addr,a",po::value<std::string>(),
+          "HTTP server addr")("http_port,p", po::value<int>(),
+                              "HTTP server port")("help,h",
+                                                  "Print this help "
+                                                  "message");
   int unix_style = postyle::unix_style | postyle::short_allow_next;
   bool driver_restart(true);
 
@@ -124,6 +126,8 @@ int main(int argc, char* argv[]) {
     if (config == nullptr) {
       return EXIT_FAILURE;
     }
+
+    config->set_http_addr_str(vm["http_addr"].as<std::string>());
     /* override configuration according to command line args */
     if (vm.count("http_port")) {
       config->set_http_port(vm["http_port"].as<int>());


### PR DESCRIPTION
Hi,

I tried to allow WebUI to run at a different address than the interface for AES67 in a multi-home environment.
You can specify the address for webUI with the -a option when running aes67-daemon as follows

```
$ aes67-daemon -a 198.51.100.2 -p 8080
```

If the -a option is not specified, webUI will be launched with the IP address assigned to the "interface_name" specified in daemon.conf as before.
If the -a option is `0.0.0.0.0`, webUI is accessible from all interfaces.

If you like this, merge it.