### PR TITLE
Compile the daemon in parallel.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,6 @@ cd ..
 cd daemon
 echo "Building aes67-daemon ..."
 cmake -DCPP_HTTPLIB_DIR="$TOPDIR"/3rdparty/cpp-httplib -DRAVENNA_ALSA_LKM_DIR="$TOPDIR"/3rdparty/ravenna-alsa-lkm -DENABLE_TESTS=ON -DWITH_AVAHI=ON -DFAKE_DRIVER=OFF -DWITH_SYSTEMD=ON .
-make
+make -j
 cd ..
 


### PR DESCRIPTION
The compilation can be a bit slow when done sequentially. The `-j` option automatically picks the number of parallel build jobs based on the number of available cores.

The parallelization might be a concern then building on systems with a small amount of RAM, that can be addressed when such occasion arises.

As a side note, in many build systems, we leave the `make` stage to be executed separately by the user, so that the user can pick the level of parallelization. There are a few invocations of `make` in the build.sh script, I'm adding the `-j` flag only to the one that was slow in practice.