### PR TITLE
Use `--timestamping` to avoid re-downloading.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,11 +26,8 @@ fi
 cd ..
 
 cd webui
-if  [ -f webui.tar.gz ]; then
-  rm -f webui.tar.gz
-fi
 echo "Downloading current webui release ..."
-wget https://github.com/bondagit/aes67-linux-daemon/releases/latest/download/webui.tar.gz
+wget --timestamping https://github.com/bondagit/aes67-linux-daemon/releases/latest/download/webui.tar.gz
 if [ -f webui.tar.gz ]; then
   tar -xzvf webui.tar.gz
 else


### PR DESCRIPTION
When a newer version of the file appears, wget will automatically update the file on disk.