### PR TITLE
Split the cmake invocation into multiple lines.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,14 @@ cd ..
 
 cd daemon
 echo "Building aes67-daemon ..."
-cmake -DCPP_HTTPLIB_DIR="$TOPDIR"/3rdparty/cpp-httplib -DRAVENNA_ALSA_LKM_DIR="$TOPDIR"/3rdparty/ravenna-alsa-lkm -DENABLE_TESTS=ON -DWITH_AVAHI=ON -DFAKE_DRIVER=OFF -DWITH_SYSTEMD=ON .
+cmake \
+	-DCPP_HTTPLIB_DIR="${TOPDIR}/3rdparty/cpp-httplib" \
+	-DRAVENNA_ALSA_LKM_DIR="${TOPDIR}/3rdparty/ravenna-alsa-lkm" \
+	-DENABLE_TESTS=ON \
+	-DWITH_AVAHI=ON \
+	-DFAKE_DRIVER=OFF \
+	-DWITH_SYSTEMD=ON \
+	.
 make
 cd ..
 

--- a/buildfake.sh
+++ b/buildfake.sh
@@ -26,7 +26,13 @@ cd ..
 
 cd daemon
 echo "Building aes67-daemon ..."
-cmake -DCPP_HTTPLIB_DIR="$TOPDIR"/3rdparty/cpp-httplib -DRAVENNA_ALSA_LKM_DIR="$TOPDIR"/3rdparty/ravenna-alsa-lkm -DENABLE_TESTS=ON -DWITH_AVAHI=OFF -DFAKE_DRIVER=ON .
+cmake \
+	-DCPP_HTTPLIB_DIR="${TOPDIR}/3rdparty/cpp-httplib" \
+	-DRAVENNA_ALSA_LKM_DIR="${TOPDIR}/3rdparty/ravenna-alsa-lkm" \
+	-DENABLE_TESTS=ON \
+	-DWITH_AVAHI=OFF \
+	-DFAKE_DRIVER=ON \
+	.
 make
 cd ..
 


### PR DESCRIPTION
The `-D` statements are lined up and easier to read. It's also easier to compare the `build.sh` and `buildfake.sh` files side-by-side.