### PR TITLE
Define mount point as "/" rather than nullptr.

### DIFF
--- a/daemon/http_server.cpp
+++ b/daemon/http_server.cpp
@@ -83,7 +83,7 @@ bool HttpServer::init() {
     return false;
   }
 
-  svr_.set_mount_point(nullptr, config_->get_http_base_dir().c_str());
+  svr_.set_mount_point("/", config_->get_http_base_dir().c_str());
 
   svr_.Get("(/|/Config|/PTP|/Sources|/Sinks|/Browser)",
            [&](const Request& req, Response& res) {


### PR DESCRIPTION
This fixes the stuckness in the newer versions of httplib. I compiled and ran the daemon using
https://github.com/yhirose/cpp-httplib/tree/c8bcaf8a913f1ac087b076488e0cbbc272cccd19 which is the newest cpp-httplib version at the time of writing.