### PR TITLE
Use cpp-httplib via a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "3rdparty/cpp-httplib"]
+	path = 3rdparty/cpp-httplib
+	url = git@github.com:bondagit/cpp-httplib.git

--- a/3rdparty/.gitignore
+++ b/3rdparty/.gitignore
@@ -1,3 +1,1 @@
 /ravenna-alsa-lkm
-/cpp-httplib
-

--- a/build.sh
+++ b/build.sh
@@ -17,14 +17,6 @@ if [ ! -d ravenna-alsa-lkm ]; then
   cd ../..
 fi
 
-if [ ! -d cpp-httplib ]; then
-  git clone https://github.com/bondagit/cpp-httplib.git
-  cd cpp-httplib
-  git checkout 42f9f9107f87ad2ee04be117dbbadd621c449552
-  cd ..
-fi
-cd ..
-
 cd webui
 echo "Downloading current webui release ..."
 wget --timestamping https://github.com/bondagit/aes67-linux-daemon/releases/latest/download/webui.tar.gz


### PR DESCRIPTION
This removes the need to script out the fetching of the other repository. Submodule stores the version of the sub-repository.

This patch also removes the use of the specific revision 42f9f9107f87ad2ee04be117dbbadd621c449552 of the bondagit/cpp-httplib repository. I'm guessing this was related to pull request #169 – this problem is now gone. We can of course configure the submodule to pull in the 42f9f9107f87ad2ee04be117dbbadd621c449552 revision.