### PR TITLE
aes67-daemon: Make dependency on libfaac optional

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -12,6 +12,7 @@ option(FAKE_DRIVER "Use fake driver instead of RAVENNA" OFF)
 set(CMAKE_CXX_STANDARD 17)
 
 option(WITH_SYSTEMD "Include systemd notify and watchdog support" OFF)
+option(WITH_STREAMER "Enable streamer support" ON)
 
 # ravena lkm _should_ be provided by the CLI. Nonetheless, we should be able
 # to find it in system dirs too...
@@ -24,9 +25,6 @@ if (NOT CPP_HTTPLIB_DIR)
     find_path( CPP_HTTPLIB_DIR "httplib.h" REQUIRED)
 endif()
 
-find_library(ALSA_LIBRARY NAMES asound)
-find_library(AAC_LIBRARY NAMES faac)
-
 find_library(AVAHI_LIBRARY-COMMON NAMES avahi-common)
 find_library(AVAHI_LIBRARY-CLIENT NAMES avahi-client)
 find_path(AVAHI_INCLUDE_DIR avahi-client/publish.h)
@@ -37,7 +35,13 @@ find_package(Boost COMPONENTS system thread log program_options REQUIRED)
 include_directories(aes67-daemon ${RAVENNA_ALSA_LKM_DIR}/common ${RAVENNA_ALSA_LKM_DIR}/driver ${CPP_HTTPLIB_DIR} ${Boost_INCLUDE_DIR})
 add_definitions( -DBOOST_LOG_DYN_LINK -DBOOST_LOG_USE_NATIVE_SYSLOG )
 add_compile_options( -Wall )
-set(SOURCES error_code.cpp json.cpp main.cpp session_manager.cpp http_server.cpp config.cpp interface.cpp log.cpp sap.cpp browser.cpp rtsp_client.cpp mdns_client.cpp mdns_server.cpp rtsp_server.cpp utils.cpp streamer.cpp)
+set(SOURCES error_code.cpp json.cpp main.cpp session_manager.cpp http_server.cpp config.cpp interface.cpp log.cpp sap.cpp browser.cpp rtsp_client.cpp mdns_client.cpp mdns_server.cpp rtsp_server.cpp utils.cpp)
+
+if(WITH_STREAMER)
+  MESSAGE(STATUS "WITH_STREAMER")
+  add_definitions(-DUSE_STREAMER)
+  list(APPEND SOURCES streamer.cpp)
+endif()
 
 if(FAKE_DRIVER)
   MESSAGE(STATUS "FAKE_DRIVER")
@@ -52,7 +56,7 @@ if(ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
 
-target_link_libraries(aes67-daemon ${Boost_LIBRARIES} ${ALSA_LIBRARY} ${AAC_LIBRARY})
+target_link_libraries(aes67-daemon ${Boost_LIBRARIES})
 if(WITH_AVAHI)
   MESSAGE(STATUS "WITH_AVAHI")
   add_definitions(-D_USE_AVAHI_)
@@ -64,4 +68,10 @@ if(WITH_SYSTEMD)
   MESSAGE(STATUS "WITH_SYSTEMD")
   add_definitions(-D_USE_SYSTEMD_)
   target_link_libraries(aes67-daemon systemd)
+endif()
+
+if(WITH_STREAMER)
+  find_library(ALSA_LIBRARY NAMES asound)
+  find_library(AAC_LIBRARY NAMES faac)
+  target_link_libraries(aes67-daemon ${ALSA_LIBRARY} ${AAC_LIBRARY})
 endif()

--- a/daemon/http_server.cpp
+++ b/daemon/http_server.cpp
@@ -323,6 +323,7 @@ bool HttpServer::init() {
            });
 
   /* retrieve streamer info and position */
+#ifdef USE_STREAMER
   svr_.Get("/api/streamer/info/([0-9]+)", [this](const Request& req,
                                                  Response& res) {
     uint32_t id;
@@ -377,10 +378,12 @@ bool HttpServer::init() {
     set_headers(res, "application/json");
     res.body = streamer_info_to_json(info);
   });
+#endif
 
   /* retrieve streamer file */
   svr_.Get("/api/streamer/stream/([0-9]+)/([0-9]+)", [this](const Request& req,
                                                             Response& res) {
+#ifdef USE_STREAMER
     if (!config_->get_streamer_enabled()) {
       set_error(400, "streamer not enabled", res);
       return;
@@ -411,6 +414,9 @@ bool HttpServer::init() {
     res.set_header("X-File-Count", std::to_string(fileCount));
     res.set_header("X-File-Current-Id", std::to_string(currentFileId));
     res.set_header("X-File-Start-Id", std::to_string(startFileId));
+#else
+    set_error(400, "streamer support not compiled-in", res);
+#endif
   });
 
   svr_.set_logger([](const Request& req, const Response& res) {

--- a/daemon/http_server.hpp
+++ b/daemon/http_server.hpp
@@ -25,18 +25,25 @@
 #include "browser.hpp"
 #include "config.hpp"
 #include "session_manager.hpp"
+
+#ifdef USE_STREAMER
 #include "streamer.hpp"
+#endif
 
 class HttpServer {
  public:
   HttpServer() = delete;
   explicit HttpServer(std::shared_ptr<SessionManager> session_manager,
                       std::shared_ptr<Browser> browser,
+#ifdef USE_STREAMER
                       std::shared_ptr<Streamer> streamer,
+#endif
                       std::shared_ptr<Config> config)
       : session_manager_(session_manager),
         browser_(browser),
+#ifdef USE_STREAMER
         streamer_(streamer),
+#endif
         config_(config){};
   bool init();
   bool terminate();
@@ -44,7 +51,9 @@ class HttpServer {
  private:
   std::shared_ptr<SessionManager> session_manager_;
   std::shared_ptr<Browser> browser_;
+#ifdef USE_STREAMER
   std::shared_ptr<Streamer> streamer_;
+#endif
   std::shared_ptr<Config> config_;
   httplib::Server svr_;
   std::future<bool> res_;

--- a/daemon/json.cpp
+++ b/daemon/json.cpp
@@ -290,6 +290,7 @@ std::string remote_sources_to_json(const std::list<RemoteSource>& sources) {
   return ss.str();
 }
 
+#ifdef USE_STREAMER
 std::string streamer_info_to_json(const StreamerInfo& info) {
   std::stringstream ss;
   ss << "{"
@@ -304,6 +305,7 @@ std::string streamer_info_to_json(const StreamerInfo& info) {
      << ",\n   \"rate\": " << unsigned(info.rate) << "\n}\n";
   return ss.str();
 }
+#endif
 
 Config json_to_config_(std::istream& js, Config& config) {
   try {

--- a/daemon/json.hpp
+++ b/daemon/json.hpp
@@ -24,7 +24,10 @@
 
 #include "browser.hpp"
 #include "session_manager.hpp"
+
+#ifdef USE_STREAMER
 #include "streamer.hpp"
+#endif
 
 /* JSON serializers */
 std::string config_to_json(const Config& config);
@@ -39,7 +42,9 @@ std::string streams_to_json(const std::list<StreamSource>& sources,
                             const std::list<StreamSink>& sinks);
 std::string remote_source_to_json(const RemoteSource& source);
 std::string remote_sources_to_json(const std::list<RemoteSource>& sources);
+#ifdef USE_STREAMER
 std::string streamer_info_to_json(const StreamerInfo& info);
+#endif
 
 /* JSON deserializers */
 Config json_to_config(std::istream& jstream, const Config& curCconfig);

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -30,7 +30,10 @@
 #include "mdns_server.hpp"
 #include "rtsp_server.hpp"
 #include "session_manager.hpp"
+
+#ifdef USE_STREAMER
 #include "streamer.hpp"
+#endif
 
 #ifdef _USE_SYSTEMD_
 #include <systemd/sd-daemon.h>
@@ -181,6 +184,7 @@ int main(int argc, char* argv[]) {
       }
 
       /* start streamer */
+#ifdef USE_STREAMER
       auto streamer = Streamer::create(session_manager, config);
       if (config->get_streamer_enabled() &&
           (streamer == nullptr || !streamer->init())) {
@@ -189,6 +193,9 @@ int main(int argc, char* argv[]) {
 
       /* start http server */
       HttpServer http_server(session_manager, browser, streamer, config);
+#else
+      HttpServer http_server(session_manager, browser, config);
+#endif
       if (!http_server.init()) {
         throw std::runtime_error(std::string("HttpServer:: init failed"));
       }
@@ -247,11 +254,13 @@ int main(int argc, char* argv[]) {
       }
 
       /* stop streamer */
+#ifdef USE_STREAMER
       if (config->get_streamer_enabled()) {
         if (!streamer->terminate()) {
           throw std::runtime_error(std::string("Streamer:: terminate failed"));
         }
       }
+#endif
 
       /* stop rtsp server */
       if (!rtsp_server.terminate()) {


### PR DESCRIPTION
I found that after a recent upgrade of the daemon, it would no longer build on my CI setup. Digging into the issue, this seems to be due to the new `libfaac` dependency which I cannot easily satisfy on my CI since it is expected to run entirley on Debian `main` (no non-free components enabled).

I would thus like to ask for a possibility to build without this new dependency if possible. A proof-of-concept patch is attached. If it is good enough, feel free to include it into the upstream. If not, please tell me if it would be possible to allow for a build without libfaac and what approach you would suggest for implementing it?

Thanks in advance and Kind regards
Linux-Fan (@m7a)

Commit message:

> Previously, since the introduction of the streamer support in version 2.0.0, it was impossible to compile the daemon without a dependency on libfaac. This prevented the daemon from being built on Debian systems without `non-free` repositories enabled. It seems the issue with libfaac is that it is based on code with a non-DFSG compliant license.
>
> This commit introduces a new config option WITH_STREAMER which is ON by default, causing the behaviour to stay backwards-compatible with the one before this commit. It is newly possible to pass `-DWITH_STREAMER=OFF` to cmake to build without streamer support and without the dependency on libfaac.