### PR TITLE
When kernel module build fails, stop.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,11 @@
 #export CC=/usr/bin/clang
 #export CXX=/usr/bin/clang++
 
+die() {
+	echo >&2 "ERROR: $*"
+	exit 1
+}
+
 TOPDIR=$(pwd)
 
 echo "Init git submodules ..."
@@ -14,7 +19,7 @@ git submodule update --init --recursive
 
 cd 3rdparty/ravenna-alsa-lkm/driver
 git checkout aes67-daemon
-make
+make || die "Building the ALSA kernel module failed"
 cd -
 
 cd webui


### PR DESCRIPTION
Handling a specific error message is easier than wondering why the kernel module is missing: did I miss a step, or did something fail?